### PR TITLE
Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - name: Fetch packages
-        run: yarn ci
+        run: yarn install
       - name: Build production build
         run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build MYR
+
+on: [push, pull_request]
+
+jobs:
+  ci-checks:
+    runs-on: ubuntu-latest
+    container:
+      image: node:10.13
+    
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Fetch packages
+        run: yarn ci
+      - name: Build production build
+        run: yarn build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Log into Quay
         run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
       - name: Build the docker image
-        run: docker build -t quay.io/umlecg/myr-admin .
+        run: docker build -t quay.io/umlecg/myr-admin:${BRANCH_NAME} .
       - name: Push the new image
         run: docker push quay.io/umlecg/myr-admin:${BRANCH_NAME}
       - name: Notify the build repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy MYR
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  update_upstream:
+    runs-on: ubuntu-latest
+    container:
+      image: docker
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set the branch variable
+        uses: nelonoel/branch-name@v1.0.1
+      - name: Log into Quay
+        run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
+      - name: Build the docker image
+        run: docker build -t quay.io/ecgmyr/myr-admin .
+      - name: Push the new image
+        run: docker push quay.io/ecgmyr/myr-admin:${BRANCH_NAME}
+      - name: Notify the build repository
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.MYR_ACCESS_TOKEN }}
+          event-type: update_${BRANCH_NAME}
+          repository: engaging-computing/MYR-build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Log into Quay
         run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
       - name: Build the docker image
-        run: docker build -t quay.io/ecgmyr/myr-admin .
+        run: docker build -t quay.io/umlecg/myr-admin .
       - name: Push the new image
-        run: docker push quay.io/ecgmyr/myr-admin:${BRANCH_NAME}
+        run: docker push quay.io/umlecg/myr-admin:${BRANCH_NAME}
       - name: Notify the build repository
         uses: peter-evans/repository-dispatch@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:10.13
+
+WORKDIR /app
+COPY . /app
+
+RUN yarn install
+RUN yarn build


### PR DESCRIPTION
This adds support for building a docker image for this repository.  This will then be used to make deployments easier.

This also moves CI to GitHub Actions since it has better support for triggering other pipelines, which is required for MYR-build to work.